### PR TITLE
Minor bug fixes

### DIFF
--- a/algosec/api_client.py
+++ b/algosec/api_client.py
@@ -159,7 +159,6 @@ class BusinessFlowAPIClient(RESTAPIClient):
         session.verify = self.verify_ssl
         response = session.get(url, auth=(self.user, self.password))
         if response.status_code == httplib.OK:
-            session.cookies.update({"JSESSIONID": response.json().get('jsessionid')})
             return session
         else:
             raise AlgoSecLoginError(

--- a/algosec/models.py
+++ b/algosec/models.py
@@ -59,21 +59,6 @@ class RequestedFlow(object):
         self.destination_to_containing_object_ids = {}
         self.aggregated_network_services = set()
 
-        self._normalize_network_services()
-
-    # TODO: Could be removed when all of the issues with case sensitivity are cleared on the BusinessFlow API
-    def _normalize_network_services(self):
-        # A new list to store normalized network services names. proto/port definition are made capital case
-        # Currently AlgoSec servers support only uppercase protocol names across the board
-        # For example: Trying to create a flow with service "tcp/54" will fail if there is only service named "TCP/54"
-        # But then creating the exact same service "tcp/54" will give an exception that the service already exists
-        normalized_network_services = []
-        for service in self.network_services:
-            if LiteralService.is_protocol_string(service):
-                service = service.upper()
-            normalized_network_services.append(service)
-        self.network_services = normalized_network_services
-
     def _api_named_object(self, lst):
         """
         ABF expect to get most simple objects as a dict pointing to their name


### PR DESCRIPTION

- unnecessary session cookie update was removed from login process
- network services normalization removed due to bugfixes in AlgoSec server
network service names normalization is no longer needed since AlgoSec
version 2017.3