### PR TITLE
Fix documentation for API clients

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,3 +16,4 @@ coveralls = "*"
 # Remove these two when all old tests have been migrated to pytest
 mock = "*"
 pyhamcrest = "*"
+sphinx = "*"

--- a/docs/api_clients.rst
+++ b/docs/api_clients.rst
@@ -5,12 +5,11 @@ Welcome! This page explain the best way to use ``algosec`` API clients.
 We'll start with a short brief description of the module and its constitutions followed by in-depth
 explanation and exploration of each of the API Clients.
 
-.. automodule:: algosec.api_client
-
 
 BusinessFlow API Client
 -----------------------
 
+.. automodule:: algosec.api_clients.business_flow
 .. autoclass:: BusinessFlowAPIClient
     :members:
 
@@ -18,6 +17,7 @@ BusinessFlow API Client
 FirewallAnalyzer API Client
 ---------------------------
 
+.. automodule:: algosec.api_clients.firewall_analyzer
 .. autoclass:: FirewallAnalyzerAPIClient
     :members:
 
@@ -25,6 +25,7 @@ FirewallAnalyzer API Client
 FireFlow API Client
 -------------------
 
+.. automodule:: algosec.api_clients.fire_flow
 .. autoclass:: FireFlowAPIClient
     :members:
 


### PR DESCRIPTION
documentation for the api clients was missing since the refactoring that splitted them into separate files. Now the documentation for those is fixed.