### PR TITLE
Fix missing api_clients from pypi package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from codecs import open
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # Get the long description from the README file
 with open("README.rst") as f:
@@ -9,7 +9,7 @@ with open("README.rst") as f:
 setup(
     name="algosec",
     version="1.0.5",
-    packages=["algosec"],
+    packages=find_packages(exclude=['tests', 'tests.*']),
     url="https://github.com/algosec/algosec-python",
     license="MIT",
     author="Almog Cohen",


### PR DESCRIPTION
`api_clients` folder was missing from pypi deployments!

To fix it, we simply enabled `find_packages` in the `setup.py` file.

This bug was found thanks to helpful customer feedback. Thanks!
