### PR TITLE
Better logging and error messages for SOAP calls

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ twine = "*"
 tox = "*"
 pytest = "*"
 pytest-cov = "*"
+pytest-responses = "*"
 coveralls = "*"
 # Remove these two when all old tests have been migrated to pytest
 mock = "*"

--- a/algosec/api_clients/base.py
+++ b/algosec/api_clients/base.py
@@ -6,15 +6,14 @@ specific API client implementations. Classes here are used by all three clients 
 """
 import logging
 import traceback
-from contextlib import contextmanager
 
 import requests
 import suds_requests
 from requests import HTTPError
-from suds import client, WebFault
-from suds.transport import TransportError
+from suds import client
 
 from algosec.errors import AlgoSecAPIError
+from algosec.helpers import report_soap_failure, LogSOAPMessages
 
 logger = logging.getLogger(__name__)
 
@@ -40,40 +39,6 @@ class APIClient(object):
         self.user = user
         self.password = password
         self.verify_ssl = verify_ssl
-
-
-@contextmanager
-def report_soap_failure(exception_to_raise):
-    """
-    Handle soap calls and raise proper exception when needed.
-
-    Used as a context manager by wrapping the code blocks with soap calls
-
-    Args:
-        exception_to_raise (algosec.errors.AlgoSecAPIError): The exception type that should be
-            raised in case of execution failure.
-
-    Returns:
-        Nothing. Used as
-    """
-    reason = "SOAP API call failed."
-    try:
-        yield
-    except WebFault:
-        # Handle exceptions in SOAP logical level
-        raise exception_to_raise(reason)
-    except TransportError as e:
-        # Handle exceptions at the transport layer
-        # For example, when getting status code 500 from the server upon mere HTTP request
-        # This code assumes that the transport error is raised by the suds_requests package.
-        status_code = e.httpcode
-        response_content = e.fp.read()
-        reason += ' status_code: {}, response_content: {}'.format(status_code, response_content)
-        raise exception_to_raise(
-            reason,
-            status_code=status_code,
-            response_content=response_content,
-        )
 
 
 class RESTAPIClient(APIClient):
@@ -193,4 +158,9 @@ class SoapAPIClient(APIClient):
         session.verify = self.verify_ssl
         # use ``requests`` based suds implementation to handle AlgoSec's self-signed certificate properly.
         with report_soap_failure(AlgoSecAPIError):
-            return client.Client(wsdl_path, transport=suds_requests.RequestsTransport(session), **kwargs)
+            return client.Client(
+                wsdl_path,
+                transport=suds_requests.RequestsTransport(session),
+                plugins=[LogSOAPMessages()],
+                **kwargs
+            )

--- a/algosec/api_clients/fire_flow.py
+++ b/algosec/api_clients/fire_flow.py
@@ -14,7 +14,8 @@ Examples:
 """
 import logging
 
-from algosec.api_clients.base import SoapAPIClient, report_soap_failure
+from algosec.api_clients.base import SoapAPIClient
+from algosec.helpers import report_soap_failure
 from algosec.errors import AlgoSecLoginError, AlgoSecAPIError
 
 logger = logging.getLogger(__name__)

--- a/algosec/api_clients/fire_flow.py
+++ b/algosec/api_clients/fire_flow.py
@@ -14,9 +14,7 @@ Examples:
 """
 import logging
 
-from suds import WebFault
-
-from algosec.api_clients.base import SoapAPIClient
+from algosec.api_clients.base import SoapAPIClient, report_soap_failure
 from algosec.errors import AlgoSecLoginError, AlgoSecAPIError
 
 logger = logging.getLogger(__name__)
@@ -58,13 +56,11 @@ class FireFlowAPIClient(SoapAPIClient):
             suds.client.Client
         """
         client = self._get_soap_client(self._wsdl_url_path)
-        try:
+        with report_soap_failure(AlgoSecLoginError):
             authenticate = client.service.authenticate(
                 username=self.user,
                 password=self.password,
             )
-        except WebFault:
-            raise AlgoSecLoginError
 
         self._session_id = authenticate.sessionId
         return client
@@ -135,10 +131,8 @@ class FireFlowAPIClient(SoapAPIClient):
             ticket.trafficLines.append(self._create_soap_traffic_line(traffic_line))
 
         # Actually create the ticket
-        try:
+        with report_soap_failure(AlgoSecAPIError):
             ticket_added = self.client.service.createTicket(sessionId=self._session_id, ticket=ticket)
-        except WebFault:
-            raise AlgoSecAPIError
 
         ticket_url = ticket_added.ticketDisplayURL
         return ticket_url
@@ -158,11 +152,6 @@ class FireFlowAPIClient(SoapAPIClient):
         Returns:
             The change request ticket object.
         """
-        try:
+        with report_soap_failure(AlgoSecAPIError):
             response = self.client.service.getTicket(sessionId=self._session_id, ticketId=change_request_id)
-        except WebFault as e:
-            if 'Can not get ticket for id' in e.fault.faultstring:
-                raise AlgoSecAPIError("Change request was not found on the server.")
-            # some other unknown error occurred
-            raise AlgoSecAPIError
         return response.ticket

--- a/algosec/api_clients/firewall_analyzer.py
+++ b/algosec/api_clients/firewall_analyzer.py
@@ -26,7 +26,8 @@ Examples:
 import logging
 from collections import OrderedDict
 
-from algosec.api_clients.base import SoapAPIClient, report_soap_failure
+from algosec.api_clients.base import SoapAPIClient
+from algosec.helpers import report_soap_failure
 from algosec.errors import AlgoSecLoginError, AlgoSecAPIError, UnrecognizedAllowanceState
 from algosec.models import DeviceAllowanceState
 

--- a/algosec/errors.py
+++ b/algosec/errors.py
@@ -13,17 +13,20 @@ class AlgoSecAPIError(Exception):
     Attributes:
         response: The response object that caused the error.
             If it was not passed to the constructor, will be None.
-        response_json (dict): The JSON of the response that caused the error.
-            Will be None if is not available.
+        response_content (dict|str): The content of the response that caused the error.
+            If it is a JSON, a JSON will be stored and not the raw content. Will be None if is not passed.
+        status_code (int): The status code of the response of the failed API call. (Optional)
 
     Keyword Args:
         response: The response object that caused the error. (Optional)
-        response_json (dict): The JSON of the response that caused the error. (Optional)
+        response_content (dict): The content of the response of the failed API call. (Optional)
+        status_code (int): The status code of the response of the failed API call. (Optional)
     """
     def __init__(self, *args, **kwargs):
         """Initialize RequestException with `request` and `response` objects."""
         self.response = kwargs.pop('response', None)
-        self.response_json = kwargs.pop('response_json', None)
+        self.status_code = kwargs.pop('status_code', None)
+        self.response_content = kwargs.pop('response_content', None)
         super(AlgoSecAPIError, self).__init__(*args, **kwargs)
 
 

--- a/algosec/helpers.py
+++ b/algosec/helpers.py
@@ -14,9 +14,6 @@ from suds.plugin import MessagePlugin
 from suds.transport import TransportError
 
 
-log = logging.getLogger(__name__)
-
-
 class AlgoSecServersHTTPAdapter(HTTPAdapter):
     """HTTP adapter to customize ``requests`` sessions with AlgoSec's servers.
 
@@ -103,11 +100,12 @@ def report_soap_failure(exception_to_raise):
 class LogSOAPMessages(MessagePlugin, object):
     """Used to send soap log messages into the builtin logging module"""
     def __init__(self, level=logging.DEBUG):
+        self.log = logging.getLogger(__name__)
         self.level = level
         super(LogSOAPMessages, self).__init__()
 
     def sending(self, context):
-        log.log(logging.DEBUG, "Sending SOAP message: {}".format(str(context.envelope)))
+        self.log.log(self.level, "Sending SOAP message: {}".format(str(context.envelope)))
 
     def received(self, context):
-        log.log(logging.DEBUG, "Received SOAP message: {}".format(str(context.reply)))
+        self.log.log(self.level, "Received SOAP message: {}".format(str(context.reply)))

--- a/algosec/helpers.py
+++ b/algosec/helpers.py
@@ -99,13 +99,14 @@ def report_soap_failure(exception_to_raise):
 # LogSOAPMessages inherit from `object` as the `MessagePlugin` is not defined as new-style class object
 class LogSOAPMessages(MessagePlugin, object):
     """Used to send soap log messages into the builtin logging module"""
-    def __init__(self, level=logging.DEBUG):
+    LOG_LEVEL = logging.DEBUG
+
+    def __init__(self):
         self.log = logging.getLogger(__name__)
-        self.level = level
         super(LogSOAPMessages, self).__init__()
 
     def sending(self, context):
-        self.log.log(self.level, "Sending SOAP message: {}".format(str(context.envelope)))
+        self.log.log(self.LOG_LEVEL, "Sending SOAP message: {}".format(str(context.envelope)))
 
     def received(self, context):
-        self.log.log(self.level, "Received SOAP message: {}".format(str(context.reply)))
+        self.log.log(self.LOG_LEVEL, "Received SOAP message: {}".format(str(context.reply)))

--- a/algosec/helpers.py
+++ b/algosec/helpers.py
@@ -99,7 +99,8 @@ def report_soap_failure(exception_to_raise):
         )
 
 
-class LogSOAPMessages(MessagePlugin):
+# LogSOAPMessages inherit from `object` as the `MessagePlugin` is not defined as new-style class object
+class LogSOAPMessages(MessagePlugin, object):
     """Used to send soap log messages into the builtin logging module"""
     def __init__(self, level=logging.DEBUG):
         self.level = level

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     install_requires=[
         "requests",
         "enum34",
-        "suds-jurko",
-        "suds_requests",
+        "suds-jurko>=0.6",
+        "suds_requests>=0.4.0",
         "ipaddress",
         "six",
     ],

--- a/tests/test_api_clients/test_base.py
+++ b/tests/test_api_clients/test_base.py
@@ -5,7 +5,8 @@ from mock import create_autospec, MagicMock
 from requests import Response, HTTPError
 from suds import client, WebFault
 
-from algosec.api_clients.base import APIClient, RESTAPIClient, SoapAPIClient, report_soap_failure
+from algosec.api_clients.base import APIClient, RESTAPIClient, SoapAPIClient
+from algosec.helpers import report_soap_failure
 from algosec.errors import AlgoSecAPIError
 
 

--- a/tests/test_api_clients/test_fire_flow.py
+++ b/tests/test_api_clients/test_fire_flow.py
@@ -9,7 +9,7 @@ from algosec.models import ChangeRequestTrafficLine, ChangeRequestAction
 
 class TestFireFlowAPIClient(object):
     @pytest.fixture()
-    def fireflow_client(self, request):
+    def fireflow_client(self):
         return FireFlowAPIClient(
             'server-ip',
             'username',
@@ -67,22 +67,6 @@ class TestFireFlowAPIClient(object):
 
         with pytest.raises(AlgoSecAPIError):
             fireflow_client.get_change_request_by_id(MagicMock())
-
-    @mock.patch('algosec.api_clients.fire_flow.FireFlowAPIClient.client')
-    def test_get_change_request_by_id__good_error_description_when_ticket_is_not_on_server(
-            self,
-            mock_soap_client,
-            fireflow_client
-    ):
-        change_request_id = 999999
-        soap_error = MagicMock()
-        soap_error.faultstring = 'Can not get ticket for id {}'.format(change_request_id)
-        mock_soap_client.service.getTicket.side_effect = WebFault(soap_error, document={})
-
-        with pytest.raises(AlgoSecAPIError) as excinfo:
-            fireflow_client.get_change_request_by_id(MagicMock())
-
-        assert str(excinfo.value) == 'Change request was not found on the server.'
 
     @mock.patch('algosec.api_clients.fire_flow.FireFlowAPIClient.client')
     @mock.patch('algosec.api_clients.fire_flow.FireFlowAPIClient._create_soap_traffic_line')

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,17 +2,21 @@ from algosec.errors import AlgoSecAPIError
 
 
 class TestAlgoSecAPIError(object):
-    def test_with_response_object(self):
-        response, response_json = "some-respone-obj", "some-response-json"
+    def test_with_response_object(self, mocker):
+        status_code, response_content, response = 12345, "some-response-content", mocker.MagicMock()
         error = AlgoSecAPIError(
+
+            status_code=status_code,
+            response_content=response_content,
             response=response,
-            response_json=response_json
         )
 
+        assert error.status_code == status_code
+        assert error.response_content == response_content
         assert error.response == response
-        assert error.response_json == response_json
 
     def test_with_no_response_object(self):
         error = AlgoSecAPIError()
+        assert error.status_code is None
+        assert error.response_content is None
         assert error.response is None
-        assert error.response_json is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -57,62 +57,48 @@ def test_is_ip_or_subnet(string, expected):
 class TestLogSOAPMessages(object):
     @classmethod
     def setup_class(cls):
-        logging.getLogger().setLevel(logging.NOTSET)
+        logging.getLogger().setLevel(logging.DEBUG)
 
     @classmethod
     def teardown_class(cls):
         logging.getLogger().setLevel(logging.INFO)
 
-    @pytest.mark.parametrize("level", [
-        logging.CRITICAL,
-        logging.ERROR,
-        logging.WARNING,
-        logging.INFO,
-        logging.DEBUG,
-    ])
     @pytest.mark.parametrize("message", [
         b'some bits',
         True,
         123,
         'some string'
     ])
-    def test_sending(self, caplog, level, message):
+    def test_sending(self, caplog, message):
         context = MessageContext()
         context.envelope = message
 
-        logging_plugin = LogSOAPMessages(level)
+        logging_plugin = LogSOAPMessages()
         logging_plugin.sending(context)
 
         log_records = list(caplog.records)
         assert len(log_records) == 1
         log_record = log_records[0]
 
-        assert log_record.levelno == level
+        assert log_record.levelno == logging.DEBUG
         assert log_record.message == "Sending SOAP message: {}".format(str(message))
 
-    @pytest.mark.parametrize("level", [
-        logging.CRITICAL,
-        logging.ERROR,
-        logging.WARNING,
-        logging.INFO,
-        logging.DEBUG,
-    ])
     @pytest.mark.parametrize("message", [
         b'some bits',
         True,
         123,
         'some string'
     ])
-    def test_received(self, caplog, level, message):
+    def test_received(self, caplog, message):
         context = MessageContext()
         context.reply = message
 
-        logging_plugin = LogSOAPMessages(level)
+        logging_plugin = LogSOAPMessages()
         logging_plugin.received(context)
 
         log_records = list(caplog.records)
         assert len(log_records) == 1
         log_record = log_records[0]
 
-        assert log_record.levelno == level
+        assert log_record.levelno == logging.DEBUG
         assert log_record.message == "Received SOAP message: {}".format(str(message))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,16 @@
+import logging
+
 import mock
 import pytest
 import requests
+from suds.plugin import MessageContext
 
-from algosec.helpers import mount_algosec_adapter_on_session, AlgoSecServersHTTPAdapter, is_ip_or_subnet
+from algosec.helpers import (
+    mount_algosec_adapter_on_session,
+    AlgoSecServersHTTPAdapter,
+    is_ip_or_subnet,
+    LogSOAPMessages,
+)
 
 
 @mock.patch('six.moves.builtins.super')
@@ -44,3 +52,67 @@ def test_mount_algosec_adapter_on_session(mocker):
 ])
 def test_is_ip_or_subnet(string, expected):
     assert is_ip_or_subnet(string) == expected
+
+
+class TestLogSOAPMessages(object):
+    @classmethod
+    def setup_class(cls):
+        logging.getLogger().setLevel(logging.NOTSET)
+
+    @classmethod
+    def teardown_class(cls):
+        logging.getLogger().setLevel(logging.INFO)
+
+    @pytest.mark.parametrize("level", [
+        logging.CRITICAL,
+        logging.ERROR,
+        logging.WARNING,
+        logging.INFO,
+        logging.DEBUG,
+    ])
+    @pytest.mark.parametrize("message", [
+        b'some bits',
+        True,
+        123,
+        'some string'
+    ])
+    def test_sending(self, caplog, level, message):
+        context = MessageContext()
+        context.envelope = message
+
+        logging_plugin = LogSOAPMessages(level)
+        logging_plugin.sending(context)
+
+        log_records = list(caplog.records)
+        assert len(log_records) == 1
+        log_record = log_records[0]
+
+        assert log_record.levelno == level
+        assert log_record.message == "Sending SOAP message: {}".format(str(message))
+
+    @pytest.mark.parametrize("level", [
+        logging.CRITICAL,
+        logging.ERROR,
+        logging.WARNING,
+        logging.INFO,
+        logging.DEBUG,
+    ])
+    @pytest.mark.parametrize("message", [
+        b'some bits',
+        True,
+        123,
+        'some string'
+    ])
+    def test_received(self, caplog, level, message):
+        context = MessageContext()
+        context.reply = message
+
+        logging_plugin = LogSOAPMessages(level)
+        logging_plugin.received(context)
+
+        log_records = list(caplog.records)
+        assert len(log_records) == 1
+        log_record = log_records[0]
+
+        assert log_record.levelno == level
+        assert log_record.message == "Received SOAP message: {}".format(str(message))

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pytest-mock
     pytest-cov
     pytest-mock
+    pytest-responses
     # Remove these two when all old tests have been migrated to pytest
     pyhamcrest
     mock


### PR DESCRIPTION
Following feedback from customers, it seems like we can use better exception messages for soap errors. I've implemented a wrapper that add status_code and the response content of the failed soap failure to the existing exception message

To use the enchanced SOAP logging implemented in this PR, you can simply run this before you use the SDK logging.getLogger('algosec').setLevel(logging.DEBUG). This will make the algosec logger use DEBUG level for logging, thus exposing all send/received SOAP messages into to logs.