### PR TITLE
remove the napoleon sphinx contrib dependency

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,3 +1,2 @@
 # File with requirements needed by the ReadTheDocs virtual env to process our docs
-sphinxcontrib-napoleon==0.6.1
 Sphinx==1.7.9


### PR DESCRIPTION
Napoleon is already shipped with sphinx since version 1.3 of sphinx.